### PR TITLE
bugfix/enable_disable_book_button_wrong_render

### DIFF
--- a/src/main/java/bibliotecame/back/Book/BookRepository.java
+++ b/src/main/java/bibliotecame/back/Book/BookRepository.java
@@ -23,7 +23,7 @@ public interface BookRepository extends PagingAndSortingRepository<BookModel, In
             " or lower(b.author) like %:search%" +
             " or lower(b.publisher) like %:search%" +
             " or exists (select t from b.tags t" +
-            " where lower(t.name) like %:search%)")
+            " where lower(t.name) like %:search%) order by b.title")
     Page<BookModel> findAllByTitleOrAuthorOrPublisherOrTags(Pageable pageable,@Param("search")String title);
 
     @Query(value = "select b from BookModel b where" +
@@ -32,7 +32,7 @@ public interface BookRepository extends PagingAndSortingRepository<BookModel, In
             " or lower(b.author) like %:search%" +
             " or lower(b.publisher) like %:search% " +
             " or exists (select t from b.tags t" +
-            " where lower(t.name) like %:search%)) ")
+            " where lower(t.name) like %:search%)) order by b.title")
     Page<BookModel> findAllByTitleOrAuthorOrPublisherOrTagsAndActive(Pageable pageable,@Param("search")String title);
 
 }


### PR DESCRIPTION
## Description

Books were ordered by "last time modified", so enabling/disabling a book made it change the elements order thus making the next page of the search return results it had already returned before.

For example: First page has books 1 to 10, second page should have 11 to 20, but if we modify book 7, it would go to position 20 due to it being the last one modified, making the second page show us books 12 to 20 + book 7, "losing" one result in the process.

## Checklist
- [ x ] I've created and run successfully the related unit tests
- [ x ] I've test the related endpoints with Postman
- [ x ] This pull request has 'sprint_x' as the base branch
- [ x ] This pull request has a descriptive title and description
- [ x ] This PR has no conflicts to merge 
- [ x ] I've added the QA Leader as a reviewer
