### PR TITLE
feat/US-015 Baja de prorroga

### DIFF
--- a/src/main/java/bibliotecame/back/Extension/ExtensionModel.java
+++ b/src/main/java/bibliotecame/back/Extension/ExtensionModel.java
@@ -19,12 +19,18 @@ public class ExtensionModel {
     @Column
     private LocalDate creationDate;
 
+    @Column
+    private boolean active;
+
     public ExtensionModel(LocalDate creationDate) {
         this.status = ExtensionStatus.PENDING_APPROVAL;
         this.creationDate = creationDate;
+        this.active = true;
     }
 
-    public ExtensionModel() {}
+    public ExtensionModel() {
+        this.active = true;
+    }
 
     public int getId() {
         return id;
@@ -39,4 +45,12 @@ public class ExtensionModel {
     }
 
     public void setStatus(ExtensionStatus status) { this.status = status; }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
+    }
 }

--- a/src/main/java/bibliotecame/back/Loan/LoanController.java
+++ b/src/main/java/bibliotecame/back/Loan/LoanController.java
@@ -4,6 +4,7 @@ import bibliotecame.back.Book.BookModel;
 import bibliotecame.back.Book.BookService;
 import bibliotecame.back.Copy.CopyModel;
 import bibliotecame.back.Copy.CopyService;
+import bibliotecame.back.Extension.ExtensionService;
 import bibliotecame.back.User.UserModel;
 import bibliotecame.back.User.UserService;
 import javassist.NotFoundException;
@@ -12,18 +13,13 @@ import org.springframework.data.domain.Page;
 import org.springframework.data.domain.PageImpl;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PathVariable;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.PutMapping;
-import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
 import java.time.LocalDate;
 import java.time.Period;
-import java.util.Comparator;
 import java.util.ArrayList;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
@@ -36,13 +32,15 @@ public class LoanController {
     private final UserService userService;
     private final BookService bookService;
     private final CopyService copyService;
+    private final ExtensionService extensionService;
 
     @Autowired
-    public LoanController(LoanService loanService, UserService userService, BookService bookService, CopyService copyService) {
+    public LoanController(LoanService loanService, UserService userService, BookService bookService, CopyService copyService, ExtensionService extensionService) {
         this.loanService = loanService;
         this.userService = userService;
         this.bookService = bookService;
         this.copyService = copyService;
+        this.extensionService = extensionService;
     }
 
     @GetMapping(value = "/history")
@@ -153,6 +151,10 @@ public class LoanController {
             loanModel = loanService.getLoanById(id);
             if(loanModel.getReturnDate()!=null || loanModel.getWithdrawalDate()==null) return new ResponseEntity<>(HttpStatus.BAD_REQUEST);
             loanModel.setReturnDate( LocalDate.now() );
+            if(loanModel.getExtension()!=null){
+                loanModel.getExtension().setActive(false);
+                extensionService.saveExtension(loanModel.getExtension());
+            }
             loanService.saveLoan(loanModel);
             return new ResponseEntity<>(loanModel,HttpStatus.OK);
         }

--- a/src/test/java/bibliotecame/back/ExtensionTests.java
+++ b/src/test/java/bibliotecame/back/ExtensionTests.java
@@ -29,12 +29,13 @@ import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContext;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.core.userdetails.User;
-import static org.assertj.core.api.Assertions.assertThat;
 
 import java.time.LocalDate;
 import java.time.Period;
 import java.util.ArrayList;
 import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -106,7 +107,7 @@ public class ExtensionTests {
         userService = new UserService(userRepository, bookService);
         loanService = new LoanService(loanRepository, bookService, userService);
         extensionService = new ExtensionService(extensionRepository, loanService, userService);
-        loanController = new LoanController(loanService, userService, bookService, copyService);
+        loanController = new LoanController(loanService, userService, bookService, copyService, extensionService);
         extensionController = new ExtensionController(extensionService, userService);
 
         authentication = Mockito.mock(Authentication.class);
@@ -278,4 +279,5 @@ public class ExtensionTests {
         extensionService.saveExtension(extension2);
 
     }
+
 }


### PR DESCRIPTION
## Description

Si un prestamo tiene una prorroga, esta debe deshabilitarse cuando el prestamo es devuelto. Esta baja es del tipo lógica. Sumado a la lógica ya existente para devolver un prestamo, esta operación solo puede hacerla un administrador, y el sistema atuomáticamente verifica según corresponda:
¿El prestamo tenía una prorroga activa? Se desactiva cuando se devuelve el prestamo, y todo es guardado en la base de datos.
¿El prestamo no tenía una prorroga? Se guarda el prestamo devuelto en la base de datos y se ignora la lógica extra de la prorroga.

El test creado en LoanTests muestra este proceso:
- se crea un prestamo
- el prestamo es retirado
- se solicita y aprueba una extensión
- finalmente se devuelve el prestamo, y la extensión es dada de baja de forma lógica, y todo es persistido.

## ClubHouse Link

https://app.clubhouse.io/bibliotecame/story/91/baja-de-pr%C3%B3rroga

## Checklist
- [x] I've created and run successfully the related unit tests
- [x] I've test the related endpoints with Postman
- [x] This pull request has 'sprint_x' as the base branch
- [x] This pull request has a descriptive title and description
- [x] This PR has no conflicts to merge 
- [x] I've added the QA Leader as a reviewer
