### PR TITLE
BF-017 Modificar un libro ya no permite convertirlo en un clon de otro.

### DIFF
--- a/src/main/java/bibliotecame/back/Book/BookController.java
+++ b/src/main/java/bibliotecame/back/Book/BookController.java
@@ -85,10 +85,8 @@ public class BookController {
         if(book.getId()!=id){
             return new ResponseEntity(new ErrorMessage("¡Está intentando modificar un libro a través de otro!"),HttpStatus.BAD_REQUEST);
         }
-        if(bookService.exists(book.getTitle(),book.getAuthor(),book.getPublisher(),book.getYear())){
-            if(bookService.findByAttributeCombination(book.getTitle(),book.getAuthor(),book.getPublisher(),book.getYear()).getId()!=id){
+        if(bookService.exists(book.getTitle(),book.getAuthor(),book.getPublisher(),book.getYear()) && bookService.findByAttributeCombination(book.getTitle(),book.getAuthor(),book.getPublisher(),book.getYear()).getId()!=id){
                 return new ResponseEntity(new ErrorMessage("¡Ya existe un libro con esos datos en el sistema!"),HttpStatus.BAD_REQUEST);
-            }
         }
 
         return checkAndUpdateBook(id, book);

--- a/src/main/java/bibliotecame/back/Book/BookController.java
+++ b/src/main/java/bibliotecame/back/Book/BookController.java
@@ -82,6 +82,14 @@ public class BookController {
         if(!bookService.exists(id)){
             return unexistingBookError();
         }
+        if(book.getId()!=id){
+            return new ResponseEntity(new ErrorMessage("¡Está intentando modificar un libro a través de otro!"),HttpStatus.BAD_REQUEST);
+        }
+        if(bookService.exists(book.getTitle(),book.getAuthor(),book.getPublisher(),book.getYear())){
+            if(bookService.findByAttributeCombination(book.getTitle(),book.getAuthor(),book.getPublisher(),book.getYear()).getId()!=id){
+                return new ResponseEntity(new ErrorMessage("¡Ya existe un libro con esos datos en el sistema!"),HttpStatus.BAD_REQUEST);
+            }
+        }
 
         return checkAndUpdateBook(id, book);
     }

--- a/src/test/java/bibliotecame/back/BookTests.java
+++ b/src/test/java/bibliotecame/back/BookTests.java
@@ -639,4 +639,29 @@ public class BookTests {
         assertThat(responseEntity.getBody().getContent().size()).isEqualTo(1);
         assertThat(responseEntity.getBody().getContent().get(0).getTitle()).isEqualTo("libroCCC");
     }
+
+    @Test
+    public void testUpdatingABookToTurnItIntoAnotherExistingBook(){
+        List<GrantedAuthority> auths = new ArrayList<>();
+
+        User securityUser = new User(admin.getEmail(), admin.getPassword(), auths);
+
+        Mockito.when(authentication.getPrincipal()).thenReturn(securityUser);
+        Mockito.when(securityContext.getAuthentication()).thenReturn(authentication);
+        SecurityContextHolder.setContext(securityContext);
+
+        BookModel book1 = new BookModel("LibroQueVaASerClonado",2020,"Clon","Clonadores de libros");
+        bookService.saveBook(book1);
+        BookModel book2 = new BookModel("LibroQueVaAVolverseElOtro",2020,"Alguien poco original","Ladrones de ideas");
+        bookService.saveBook(book2);
+
+        book2 = bookService.findByAttributeCombination(book2.getTitle(),book2.getAuthor(),book2.getPublisher(),book2.getYear());
+        //Le colocamos los atributos del book1, si este nuevo book2 fuera guardado, tendríamos "dos veces" al book1 en la db.
+        book2.setAuthor(book1.getAuthor());
+        book2.setPublisher(book1.getPublisher());
+        book2.setYear(book1.getYear());
+        book2.setTitle(book1.getTitle());
+        assertThat(((ErrorMessage)bookController.updateBook(book2.getId(),book2).getBody()).getMessage()).isEqualTo("¡Ya existe un libro con esos datos en el sistema!");
+
+    }
 }


### PR DESCRIPTION
## Description

Si bien no se permite crear dos libros con la misma combinación de atributos (titulo, autor, año y editorial), el sistema permitía que un libro ya existente fuera modificado a una copia exacta de otro.
Con estos cambios, si se le da una combinación de atributos ya existente en la base de datos, verificará que ese conflicto sea con el mismo.

Es decir:
Libro A tiene id 1, Libro B tiene id 2.
Si intento darle a B los atributos de A, al verificar que esa combinación ya existe en la base de datos, verifica mediante sus id, y determina que estoy intentando "Clonar" un libro. En cambio si las id son iguales, determina que es valido ya que son el mismo libro, para evitar errores en caso de que alguien envíe a un libro su misma combinación de atributos en un update (Por ejemplo, mandar un update de libro A sin modificarle nada no dará errores).

Otra verificación que agregué, es que si estoy usando la url: book/1 y el bookModel que envié NO tiene la id 1, determinará que estoy intentando modificar un libro a través de otro y me dará el error correspondiente.
Tanto por postman como por el test unitario el intento de "clonar" un libro fué rechazado correctamente.

## ClubHouse Link

https://app.clubhouse.io/bibliotecame/story/215/bug-mod-libro

## Checklist
- [x] I've created and run successfully the related unit tests
- [x] I've run successfully every test in the repo
- [x] I've test the related endpoints with Postman
- [x] This pull request has 'sprint_x' as the base branch
- [x] This pull request has a descriptive title and description
- [x] I have merged the current sprint into my branch before pushing 
- [x] I've added the QA Leader as a reviewer
