### PR TITLE
fix/US-016 ExtensionController uses LoanID for extension approve/reject

### DIFF
--- a/src/test/java/bibliotecame/back/ExtensionTests.java
+++ b/src/test/java/bibliotecame/back/ExtensionTests.java
@@ -108,7 +108,7 @@ public class ExtensionTests {
         loanService = new LoanService(loanRepository, bookService, userService);
         extensionService = new ExtensionService(extensionRepository, loanService, userService);
         loanController = new LoanController(loanService, userService, bookService, copyService, extensionService);
-        extensionController = new ExtensionController(extensionService, userService);
+        extensionController = new ExtensionController(extensionService, userService, loanService);
 
         authentication = Mockito.mock(Authentication.class);
         securityContext = Mockito.mock(SecurityContext.class);
@@ -238,14 +238,10 @@ public class ExtensionTests {
     @Test
     void testModifyExtensionOK(){
 
-        ExtensionModel extension1 = extensionModel1;
-
-        ExtensionModel extension2 = extensionModel2;
-
         setSecurityContext(admin);
 
-        assertThat(extensionController.approveExtension(extension1.getId()).getStatusCode()).isEqualByComparingTo(HttpStatus.OK);
-        assertThat(extensionController.rejectExtension(extension2.getId()).getStatusCode()).isEqualByComparingTo(HttpStatus.OK);
+        assertThat(extensionController.approveExtension(loan3.getId()).getStatusCode()).isEqualByComparingTo(HttpStatus.OK);
+        assertThat(extensionController.rejectExtension(loan4.getId()).getStatusCode()).isEqualByComparingTo(HttpStatus.OK);
 
     }
 
@@ -254,12 +250,8 @@ public class ExtensionTests {
 
         setSecurityContext(notAdmin3);
 
-        ExtensionModel extension1 = extensionModel1;
-
-        ExtensionModel extension2 = extensionModel2;
-
-        assertThat(extensionController.approveExtension(extension1.getId()).getStatusCode()).isEqualByComparingTo(HttpStatus.UNAUTHORIZED);
-        assertThat(extensionController.rejectExtension(extension2.getId()).getStatusCode()).isEqualByComparingTo(HttpStatus.UNAUTHORIZED);
+        assertThat(extensionController.approveExtension(loan3.getId()).getStatusCode()).isEqualByComparingTo(HttpStatus.UNAUTHORIZED);
+        assertThat(extensionController.rejectExtension(loan4.getId()).getStatusCode()).isEqualByComparingTo(HttpStatus.UNAUTHORIZED);
 
     }
 

--- a/src/test/java/bibliotecame/back/LoanTests.java
+++ b/src/test/java/bibliotecame/back/LoanTests.java
@@ -98,7 +98,7 @@ public class LoanTests {
         loanService = new LoanService(loanRepository, bookService, userService);
         extensionService = new ExtensionService(extensionRepository,loanService,userService);
         loanController = new LoanController(loanService, userService, bookService, copyService,extensionService);
-        extensionController = new ExtensionController(extensionService,userService);
+        extensionController = new ExtensionController(extensionService,userService, loanService);
 
         authentication = Mockito.mock(Authentication.class);
         securityContext = Mockito.mock(SecurityContext.class);
@@ -458,7 +458,7 @@ public class LoanTests {
 
         setSecurityContext(admin);
         loanController.setWithdrawDate(loan.getId());
-        extensionModel = (ExtensionModel) extensionController.approveExtension(extensionModel.getId()).getBody();
+        extensionModel = (ExtensionModel) extensionController.approveExtension(loan.getId()).getBody();
 
         //Here we created and approved an extension
 


### PR DESCRIPTION
## Description

Como originalmente el método de aprobar o rechazar una extensión usaba la ID de dicha extensión, la cual nunca era envíada al front, era imposible acceder a dicho valor para poder aprobarla o rechazarla. Como todo prestamo solo puede tener asociada una extensión, el método ahora funciona a través de la ID del prestamo.

En caso de que el prestamo NO tenga una extensión asociada, o no exista, devuelve el error correspondiente con el mensaje acorde al mismo. Caso contrario, lo modifica exitosamente.

## Checklist
- [x] I've created and run successfully the related unit tests
- [x] I've run successfully every test in the repo
- [x] I've test the related endpoints with Postman
- [x] This pull request has 'sprint_x' as the base branch
- [x] This pull request has a descriptive title and description
- [x] I have merged the current sprint into my branch before pushing 
- [x] I've added the QA Leader as a reviewer
