### PR TITLE
The copy of a loan now becomes bookable again after returning a loan.

### DIFF
--- a/src/main/java/bibliotecame/back/Loan/LoanController.java
+++ b/src/main/java/bibliotecame/back/Loan/LoanController.java
@@ -158,6 +158,8 @@ public class LoanController {
                 loanModel.getExtension().setActive(false);
                 extensionService.saveExtension(loanModel.getExtension());
             }
+            loanModel.getCopy().setBooked(false);
+            copyService.saveCopy(loanModel.getCopy());
             loanService.saveLoan(loanModel);
             return new ResponseEntity<>(loanModel,HttpStatus.OK);
         }

--- a/src/main/java/bibliotecame/back/Loan/LoanService.java
+++ b/src/main/java/bibliotecame/back/Loan/LoanService.java
@@ -2,6 +2,7 @@ package bibliotecame.back.Loan;
 
 import bibliotecame.back.Book.BookModel;
 import bibliotecame.back.Book.BookService;
+import bibliotecame.back.Copy.CopyService;
 import bibliotecame.back.Review.ReviewModel;
 import bibliotecame.back.Review.ReviewService;
 import bibliotecame.back.User.UserModel;
@@ -21,8 +22,6 @@ import java.util.Optional;
 import java.util.stream.Collectors;
 
 import static java.lang.Math.toIntExact;
-import java.util.stream.Collectors;
-import java.util.stream.Collectors;
 
 @Service
 public class LoanService {
@@ -31,13 +30,15 @@ public class LoanService {
     private final BookService bookService;
     private final UserService userService;
     private final ReviewService reviewService;
+    private final CopyService copyService;
 
     @Autowired
-    public LoanService(LoanRepository loanRepository, BookService bookService, UserService userService, ReviewService reviewService) {
+    public LoanService(LoanRepository loanRepository, BookService bookService, UserService userService, ReviewService reviewService, CopyService copyService) {
         this.loanRepository = loanRepository;
         this.bookService = bookService;
         this.userService = userService;
         this.reviewService = reviewService;
+        this.copyService = copyService;
     }
 
     public LoanModel saveLoan(LoanModel loanModel){
@@ -124,6 +125,8 @@ public class LoanService {
         user.setLoans(remainingLoans);
         userService.saveWithoutEncryption(user);
         for(LoanModel loan: deletingLoans){
+            loan.getCopy().setBooked(false);
+            copyService.saveCopy(loan.getCopy());
             loanRepository.delete(loan);
         }
     }

--- a/src/test/java/bibliotecame/back/ExtensionTests.java
+++ b/src/test/java/bibliotecame/back/ExtensionTests.java
@@ -113,7 +113,7 @@ public class ExtensionTests {
         bookService = new BookService(bookRepository, tagService);
         userService = new UserService(userRepository, bookService);
         reviewService = new ReviewService(reviewRepository);
-        loanService = new LoanService(loanRepository, bookService, userService, reviewService);
+        loanService = new LoanService(loanRepository, bookService, userService, reviewService, copyService);
         extensionService = new ExtensionService(extensionRepository, loanService, userService);
         loanController = new LoanController(loanService, userService, bookService, copyService, extensionService);
         extensionController = new ExtensionController(extensionService, userService, loanService);

--- a/src/test/java/bibliotecame/back/ReviewTests.java
+++ b/src/test/java/bibliotecame/back/ReviewTests.java
@@ -106,7 +106,7 @@ public class ReviewTests {
         userService = new UserService(userRepository, bookService);
         bookController = new BookController(bookService, tagService, copyService, userService);
         reviewService = new ReviewService(reviewRepository);
-        loanService = new LoanService(loanRepository, bookService, userService, reviewService);
+        loanService = new LoanService(loanRepository, bookService, userService, reviewService, copyService);
         reviewController = new ReviewController(reviewService,userService,bookService);
         loanController = new LoanController(loanService,userService,bookService,copyService,extensionService);
 


### PR DESCRIPTION
## Description

Devolver un prestamo nunca marcaba su copia correspondiente como disponible de nuevo, por lo que una vez devuelto el prestamo nunca podía retirarse la misma copia de nuevo sin acceder manualmente a la db.
Ahora al devolver un prestamo / cuando un prestamo no retirado expira, su copia automáticamente se marca como disponible de nuevo.

## Checklist
- [x] I've created and run successfully the related unit tests
- [x] I've run successfully every test in the repo
- [x] I've test the related endpoints with Postman
- [x] This pull request has 'sprint_x' as the base branch
- [x] This pull request has a descriptive title and description
- [x] I have merged the current sprint into my branch before pushing 
- [x] I've added the QA Leader as a reviewer
