### PR TITLE
US-024 Envío de emails en prestamos atrasados.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ dependencies {
 	testImplementation 'com.h2database:h2'
 	compile("com.auth0:java-jwt:3.4.0")
 	compile group: 'io.jsonwebtoken', name: 'jjwt', version: '0.9.1'
+	compile group: 'com.sun.mail', name: 'javax.mail', version: '1.6.2'
+
 }
 
 test {

--- a/src/main/java/bibliotecame/back/Email/Email.java
+++ b/src/main/java/bibliotecame/back/Email/Email.java
@@ -1,0 +1,42 @@
+package bibliotecame.back.Email;
+
+import javax.mail.internet.InternetAddress;
+
+public class Email {
+    InternetAddress recipient;
+    String subject;
+    String body;
+
+    public Email() {
+    }
+
+    public Email(InternetAddress recipient, String subject, String body) {
+        this.recipient = recipient;
+        this.subject = subject;
+        this.body = body;
+    }
+
+    public InternetAddress getRecipient() {
+        return recipient;
+    }
+
+    public void setRecipient(InternetAddress recipient) {
+        this.recipient = recipient;
+    }
+
+    public String getSubject() {
+        return subject;
+    }
+
+    public void setSubject(String subject) {
+        this.subject = subject;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+}

--- a/src/main/java/bibliotecame/back/Email/EmailSender.java
+++ b/src/main/java/bibliotecame/back/Email/EmailSender.java
@@ -1,0 +1,76 @@
+package bibliotecame.back.Email;
+
+import javax.mail.*;
+import javax.mail.internet.InternetAddress;
+import javax.mail.internet.MimeMessage;
+import java.util.Properties;
+
+public class EmailSender {
+
+    public void notifyWithGmail(Address recipient, String subject, String body) {
+        String sender = "bibliotecame.notificaciones";
+        String password = "bibliotecameadmin";
+
+        Properties props = System.getProperties();
+        props.put("mail.smtp.host", "smtp.gmail.com");
+        props.put("mail.smtp.user", sender);
+        props.put("mail.smtp.clave", password);
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.smtp.port", "587");
+
+        Session session = Session.getDefaultInstance(props);
+        MimeMessage message = new MimeMessage(session);
+        try {
+            message.setContent(body, "text/html; charset=utf-8");
+        } catch (MessagingException e) {
+            e.printStackTrace();
+        }
+
+        try {
+            message.setFrom(new InternetAddress(sender));
+            message.addRecipient(Message.RecipientType.TO, recipient);
+            message.setSubject(subject);
+            message.setText(body);
+            Transport transport = session.getTransport("smtp");
+            transport.connect("smtp.gmail.com", sender, password);
+            transport.sendMessage(message, message.getAllRecipients());
+            transport.close();
+        }
+        catch (MessagingException me) {
+            me.printStackTrace();
+        }
+    }
+
+    public void notifyWithGmail(Email email) {
+        String sender = "bibliotecame.notificaciones";
+        String password = "bibliotecameadmin";
+
+        Properties props = System.getProperties();
+        props.put("mail.smtp.host", "smtp.gmail.com");
+        props.put("mail.smtp.user", sender);
+        props.put("mail.smtp.clave", password);
+        props.put("mail.smtp.auth", "true");
+        props.put("mail.smtp.starttls.enable", "true");
+        props.put("mail.smtp.port", "587");
+
+        Session session = Session.getDefaultInstance(props);
+        MimeMessage message = new MimeMessage(session);
+
+        try {
+            message.setFrom(new InternetAddress(sender));
+            message.addRecipient(Message.RecipientType.TO, email.recipient);
+            message.setSubject(email.subject);
+            message.setText(email.body);
+            message.setContent(email.body, "text/html; charset=utf-8");
+            Transport transport = session.getTransport("smtp");
+            transport.connect("smtp.gmail.com", sender, password);
+            transport.sendMessage(message, message.getAllRecipients());
+            transport.close();
+        }
+        catch (MessagingException me) {
+            me.printStackTrace();
+        }
+    }
+
+}

--- a/src/main/java/bibliotecame/back/Loan/DelayedLoanDetails.java
+++ b/src/main/java/bibliotecame/back/Loan/DelayedLoanDetails.java
@@ -1,0 +1,72 @@
+package bibliotecame.back.Loan;
+
+import bibliotecame.back.Book.BookModel;
+import bibliotecame.back.User.UserModel;
+
+import java.time.LocalDate;
+
+public class DelayedLoanDetails {
+    private int id;
+    private String bookTitle;
+    private LocalDate withdrawDate;
+    private LocalDate returnDate;
+    private String userEmail;
+    private String userName;
+
+    public DelayedLoanDetails(LoanModel loanModel, UserModel userModel, BookModel bookModel){
+        this.id= loanModel.getId();
+        this.bookTitle= bookModel.getTitle();
+        this.withdrawDate= loanModel.getWithdrawalDate();
+        this.returnDate= loanModel.getExpirationDate();
+        this.userEmail= userModel.getEmail();
+        this.userName= userModel.getFirstName();
+    }
+
+    public int getId() {
+        return id;
+    }
+
+    public void setId(int id) {
+        this.id = id;
+    }
+
+    public String getBookTitle() {
+        return bookTitle;
+    }
+
+    public void setBookTitle(String bookTitle) {
+        this.bookTitle = bookTitle;
+    }
+
+    public LocalDate getWithdrawDate() {
+        return withdrawDate;
+    }
+
+    public void setWithdrawDate(LocalDate withdrawDate) {
+        this.withdrawDate = withdrawDate;
+    }
+
+    public LocalDate getReturnDate() {
+        return returnDate;
+    }
+
+    public void setReturnDate(LocalDate returnDate) {
+        this.returnDate = returnDate;
+    }
+
+    public String getUserEmail() {
+        return userEmail;
+    }
+
+    public void setUserEmail(String userEmail) {
+        this.userEmail = userEmail;
+    }
+
+    public String getUserName() {
+        return userName;
+    }
+
+    public void setUserName(String userName) {
+        this.userName = userName;
+    }
+}

--- a/src/main/java/bibliotecame/back/Loan/LoanController.java
+++ b/src/main/java/bibliotecame/back/Loan/LoanController.java
@@ -4,6 +4,8 @@ import bibliotecame.back.Book.BookModel;
 import bibliotecame.back.Book.BookService;
 import bibliotecame.back.Copy.CopyModel;
 import bibliotecame.back.Copy.CopyService;
+import bibliotecame.back.Email.Email;
+import bibliotecame.back.Email.EmailSender;
 import bibliotecame.back.ErrorMessage;
 import bibliotecame.back.Extension.ExtensionService;
 import bibliotecame.back.User.UserModel;
@@ -16,9 +18,12 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
+import javax.mail.internet.InternetAddress;
 import javax.validation.Valid;
+import java.io.UnsupportedEncodingException;
 import java.time.LocalDate;
 import java.time.Period;
+import java.time.format.DateTimeFormatter;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
@@ -200,4 +205,49 @@ public class LoanController {
         return new ResponseEntity<>(HttpStatus.OK);
     }
 
+    @GetMapping("/delayed/check")
+    public ResponseEntity checkDelayedLoans(){
+
+        if(!getLogged().isAdmin()) return unauthorizedActionError();
+
+        return new ResponseEntity(loanService.getDelayedLoans().size()>0,HttpStatus.OK);
+    }
+
+    @GetMapping("/delayed/notify")
+    public ResponseEntity notifyDelayedLoans(){
+
+        if(!getLogged().isAdmin()) return unauthorizedActionError();
+        EmailSender sender = new EmailSender();
+
+        List<DelayedLoanDetails> delayedLoans = new ArrayList<>();
+        loanService.getDelayedLoans().forEach(loanModel -> delayedLoans.add(loanService.turnLoanModalToDelayedDetails(loanModel)));
+
+        List<String> deliveredEmails = new ArrayList<>();
+        DateTimeFormatter formatters = DateTimeFormatter.ofPattern("dd/MM/yyyy");
+        List<Email> emailsToSend = new ArrayList<>();
+
+        delayedLoans.forEach(lm -> {
+            if(!deliveredEmails.contains(lm.getUserEmail())) {
+                String body = "Estimado " + userService.findUserByEmail(lm.getUserEmail()).getFirstName() + ": <br>" +
+                        "Le recordamos que actualmente tiene los siguientes prestamos en ATRASO: <ul>";
+                List<DelayedLoanDetails> userLoans = delayedLoans.stream().filter(loan -> loan.getUserEmail().equals(lm.getUserEmail())).collect(Collectors.toList());
+                for (DelayedLoanDetails loan : userLoans) {
+                    body += "<br><li><strong>Libro:</strong> <i>\""+loan.getBookTitle()+"\"</i></li>" +
+                            "<li><strong>Fecha de Retiro:</strong> "+loan.getWithdrawDate().format(formatters)+"</li>"+
+                            "<li><strong>Fecha de Devolución:</strong> "+loan.getReturnDate().format(formatters)+"</li>";
+                }
+                body += "</ul><br>Atte, Administración Bibliotecame.";
+                try {
+                    emailsToSend.add(new Email(new InternetAddress(lm.getUserEmail(),lm.getUserName()),"Prestamos atrasados",body));
+                } catch (UnsupportedEncodingException e) {
+                    e.printStackTrace();
+                }
+                deliveredEmails.add(lm.getUserEmail());
+            }
+        });
+
+        emailsToSend.forEach(sender::notifyWithGmail);
+        //The responseEntity holds how many mails it sent in case notification/validation is needed in the future.
+        return new ResponseEntity(emailsToSend.size(),HttpStatus.OK);
+    }
 }

--- a/src/main/java/bibliotecame/back/Loan/LoanController.java
+++ b/src/main/java/bibliotecame/back/Loan/LoanController.java
@@ -229,12 +229,12 @@ public class LoanController {
         delayedLoans.forEach(lm -> {
             if(!deliveredEmails.contains(lm.getUserEmail())) {
                 String body = "Estimado " + userService.findUserByEmail(lm.getUserEmail()).getFirstName() + ": <br>" +
-                        "Le recordamos que actualmente tiene los siguientes prestamos en ATRASO: <ul>";
+                        "Le recordamos que actualmente tiene los siguientes prestamos ATRASADOS: <ul>";
                 List<DelayedLoanDetails> userLoans = delayedLoans.stream().filter(loan -> loan.getUserEmail().equals(lm.getUserEmail())).collect(Collectors.toList());
                 for (DelayedLoanDetails loan : userLoans) {
                     body += "<br><li><strong>Libro:</strong> <i>\""+loan.getBookTitle()+"\"</i></li>" +
                             "<li><strong>Fecha de Retiro:</strong> "+loan.getWithdrawDate().format(formatters)+"</li>"+
-                            "<li><strong>Fecha de Devolución:</strong> "+loan.getReturnDate().format(formatters)+"</li>";
+                            "<li><strong>Fecha de Vencimiento:</strong> "+loan.getReturnDate().format(formatters)+"</li>";
                 }
                 body += "</ul><br>Atte, Administración Bibliotecame.";
                 try {

--- a/src/main/java/bibliotecame/back/Loan/LoanService.java
+++ b/src/main/java/bibliotecame/back/Loan/LoanService.java
@@ -86,6 +86,11 @@ public class LoanService {
         return withStatus? setLoanDisplayStatus(modal, display) : display;
     }
 
+    public DelayedLoanDetails turnLoanModalToDelayedDetails(LoanModel modal){
+        BookModel book = bookService.findBookByCopy(modal.getCopy());
+        return new DelayedLoanDetails(modal,userService.getUserFromLoan(modal),book);
+    }
+
     private Integer getReviewByBook(Integer bookId){
         List<ReviewModel> userReviews = reviewService.findAllByUserModel(userService.findLogged());
         List<ReviewModel> bookReviews = bookService.findBookById(bookId).getReviews();
@@ -129,5 +134,10 @@ public class LoanService {
             copyService.saveCopy(loan.getCopy());
             loanRepository.delete(loan);
         }
+    }
+
+    public List<LoanModel> getDelayedLoans(){
+        return findAll().stream().filter(loan -> loan.getWithdrawalDate()!=null && loan.getReturnDate()==null && loan.getExpirationDate().isBefore(LocalDate.now()))
+                .collect(Collectors.toList());
     }
 }


### PR DESCRIPTION
## Description

El administrador puede mediante la ruta "/loan/delayed/notify" notificar de forma automática a todos los usuarios que tengan un prestamo (O más) atrasado. En caso de tener más de uno, se listarán todos los prestamos atrasados en el mismo correo.
Los mails se envían desde la cuenta "bibliotecame.notificaciones@gmail.com".
(Como el extender un prestamo con una prórroga le añade 3 días más a su fecha de vencimiento, se considera atrasado a cualquier prestamo que: ya tiene una fecha de retiro, y su fecha de vencimiento es previa a la fecha actual)

Además, para facilitar el uso del botón a futuro en el front, la ruta "/loan/delayed/check" notifica con un boolean, si hay o no prestamos atrasados que notificar, de modo que el botón debería renderizarse/activarse solo si este método devuelve true.

## ClubHouse Link

https://app.clubhouse.io/bibliotecame/story/99/env%C3%ADo-de-emails

## Checklist
- [x] I've created and run successfully the related unit tests
- [x] I've run successfully every test in the repo
- [x] I've test the related endpoints with Postman
- [x] This pull request has 'sprint_x' as the base branch
- [x] This pull request has a descriptive title and description
- [x] I have merged the current sprint into my branch before pushing 
- [x] I've added the QA Leader as a reviewer
