### PR TITLE
US-044 Busqueda de sanciones

### DIFF
--- a/src/main/java/bibliotecame/back/Sanction/SanctionController.java
+++ b/src/main/java/bibliotecame/back/Sanction/SanctionController.java
@@ -10,8 +10,6 @@ import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
-import java.awt.print.PageFormat;
-import java.awt.print.Pageable;
 import java.time.LocalDate;
 import java.time.Period;
 
@@ -91,5 +89,20 @@ public class SanctionController {
     private ResponseEntity unauthorizedActionError(){
         return new ResponseEntity<>(new ErrorMessage("¡Usted no está autorizado a realizar esta acción!"),HttpStatus.UNAUTHORIZED);
     }
+
+    @GetMapping(value = "/search")
+    public ResponseEntity<Page<SanctionDisplay>> getAllByEmailOrStartDateOrEndDate(
+            @Valid @RequestParam(value = "page") int page,
+            @Valid @RequestParam(value = "size", required = false, defaultValue = "10") Integer size,
+            @Valid @RequestParam(value = "search") String search
+    ) {
+        search = search.toLowerCase();
+        if (size == 0) size = 10;
+        if(!checkAdmin()) {
+            return unauthorizedActionError();
+        }
+        return ResponseEntity.ok(sanctionService.findAllByEmailOrStartDateOrEndDate(page,size,search));
+    }
+
 
 }

--- a/src/main/java/bibliotecame/back/Sanction/SanctionRepository.java
+++ b/src/main/java/bibliotecame/back/Sanction/SanctionRepository.java
@@ -21,5 +21,7 @@ public interface SanctionRepository extends PagingAndSortingRepository<SanctionM
     @Query(value = "select b from SanctionModel b where" +
             " b.endDate >= :today and " +
             " lower(b.user.email) like %:search% order by b.endDate")
-    Page<SanctionModel> findAllByUserOrReasonAndActive(Pageable pageable, @Param("search")String title, @Param("today")LocalDate today);
+    Page<SanctionModel> findAllByUserOrReasonAndActive(Pageable pageable, @Param("search") String title, @Param("today") LocalDate today);
+
+    Iterable<SanctionModel> findAll();
 }

--- a/src/main/java/bibliotecame/back/Sanction/SanctionService.java
+++ b/src/main/java/bibliotecame/back/Sanction/SanctionService.java
@@ -3,11 +3,17 @@ package bibliotecame.back.Sanction;
 import bibliotecame.back.User.UserModel;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageImpl;
 import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+
+import static java.lang.Math.toIntExact;
 
 @Service
 public class SanctionService {
@@ -34,5 +40,21 @@ public class SanctionService {
     public Page<SanctionModel> getSanctionList(int page, int size, String search){
         Pageable pageable = PageRequest.of(page, size);
         return sanctionRepository.findAllByUserOrReasonAndActive(pageable, search.toLowerCase(), LocalDate.now());
+    }
+
+    public Page<SanctionDisplay> findAllByEmailOrStartDateOrEndDate(int page, int size, String search){
+        Pageable pageable = PageRequest.of(page, size);
+        List<SanctionModel> result = new ArrayList<>();
+        sanctionRepository.findAll().iterator().forEachRemaining(result::add);
+        result = result.stream().filter(sM -> sM.getUser().getEmail().toLowerCase().contains(search) || sM.getCreationDate().toString().contains(search) || sM.getEndDate().toString().contains(search)).collect(Collectors.toList());
+        int total = result.size();
+        int start = toIntExact(pageable.getOffset());
+        int end = Math.min((start + pageable.getPageSize()), total);
+        List<SanctionDisplay> output = new ArrayList<>();
+        if (start <= end) {
+            List<SanctionModel> temp = result.subList(start, end);
+            temp.stream().forEach(sM -> output.add(new SanctionDisplay(sM.getId(),sM.getUser().getEmail(),sM.getCreationDate(),sM.getEndDate(), sM.getReason())));
+        }
+        return new PageImpl<>(output, pageable, result.size());
     }
 }


### PR DESCRIPTION
## Description

Siendo un usuario administrador, quiero poder buscar entre las sanciones para verlas con mayor facilidad o ver un grupo reducido de ellas. Para ello ahora el sistema cuenta con una busqueda básica por email del usuario sancionado, fecha de finalización o fecha de comienzo de la sanción.

Contamos con la ruta /sanction/search?page=x&size=y&search=z
-Page (X) indica el número de página, comenzando en 0
-Size (Y) indica el número de resultados por página, siendo puesto por defecto en 10 si no esta presente o si pedimos 0 por página.
-Search (Z) indica el string a buscar, puede ser un mail (o fragmento de uno) o una fecha (formato yyyy-MM-dd) (Tambien funciona con partes de una fecha)

Por ejemplo:
/sanction/search?page=0&size=5&search=2020
Nos daría la primer página de tamaño 5, que contengan 2020 en una de sus fechas ( O en su mail si el usuario fuera "pepe2020@ing.austral.edu.ar")

 /sanction/search?page=0&size=5&search=iturralde
Nos daría como resultado a la amable persona corrigiendo este PR (junto a cualquier otro Iturralde que haya en el sistema)

## ClubHouse Link

> https://app.clubhouse.io/bibliotecame/story/296/b%C3%BAsqueda-de-sanciones

## Checklist
- [x] I've created and run successfully the related unit tests
- [x] I've run successfully every test in the repo
- [x] I've test the related endpoints with Postman
- [x] This pull request has 'sprint_x' as the base branch
- [x] This pull request has a descriptive title and description
- [x] I have merged the current sprint into my branch before pushing 
- [x] I've added the QA Leader as a reviewer
