### PR TITLE
SanctionController has only one GET endpoint now.

### DIFF
--- a/src/main/java/bibliotecame/back/Sanction/SanctionController.java
+++ b/src/main/java/bibliotecame/back/Sanction/SanctionController.java
@@ -78,19 +78,15 @@ public class SanctionController {
     }
 
     @GetMapping()
-    public ResponseEntity<Page<SanctionDisplay>> getActiveOrSearch(
+    public ResponseEntity<Page<SanctionDisplay>> getActiveSanctionsWithDateOrUserFilter(
             @Valid @RequestParam(value = "page") int page,
             @Valid @RequestParam(value = "size", required = false, defaultValue = "10") Integer size,
             @Valid @RequestParam(value = "search", required = false, defaultValue = "") String search
     ) {
         search = search.toLowerCase();
         if (size == 0) size = 10;
-        if(!checkAdmin()) {
-            return unauthorizedActionError();
-        }
-        if(search.equals("") || search.toLowerCase().equals("activas")){
-           return ResponseEntity.ok(sanctionService.getActiveSanctionList(page,size));
-        } else return ResponseEntity.ok(sanctionService.findAllByEmailOrStartDateOrEndDate(page,size,search));
+        if(!checkAdmin()) return unauthorizedActionError();
+        return ResponseEntity.ok(sanctionService.findAllByEmailOrStartDateOrEndDate(page,size,search));
     }
 
 

--- a/src/main/java/bibliotecame/back/Sanction/SanctionController.java
+++ b/src/main/java/bibliotecame/back/Sanction/SanctionController.java
@@ -54,19 +54,6 @@ public class SanctionController {
         return ResponseEntity.ok(this.sanctionService.saveSanction(sanction));
     }
 
-    @GetMapping("/activeList")
-    public ResponseEntity getSanctionList( @Valid @RequestParam(value = "page") int page,
-                                           @Valid @RequestParam(value = "size", required = false, defaultValue = "10") Integer size,
-                                           @Valid @RequestParam(value = "search") String search){
-        if(!checkAdmin()) return unauthorizedActionError();
-
-        Page<SanctionModel> list = sanctionService.getSanctionList(page, size, search);
-
-        Page<SanctionDisplay> result = list.map(sm -> new SanctionDisplay(sm.getId(), sm.getUser().getEmail(), sm.getCreationDate(), sm.getEndDate(), sm.getReason()));
-
-        return ResponseEntity.ok(result);
-    }
-
     @PutMapping()
     public ResponseEntity modifySanction(@Valid @RequestBody SanctionModel sanctionModel){
         if(!checkAdmin()) return unauthorizedActionError();
@@ -90,18 +77,20 @@ public class SanctionController {
         return new ResponseEntity<>(new ErrorMessage("¡Usted no está autorizado a realizar esta acción!"),HttpStatus.UNAUTHORIZED);
     }
 
-    @GetMapping(value = "/search")
-    public ResponseEntity<Page<SanctionDisplay>> getAllByEmailOrStartDateOrEndDate(
+    @GetMapping()
+    public ResponseEntity<Page<SanctionDisplay>> getActiveOrSearch(
             @Valid @RequestParam(value = "page") int page,
             @Valid @RequestParam(value = "size", required = false, defaultValue = "10") Integer size,
-            @Valid @RequestParam(value = "search") String search
+            @Valid @RequestParam(value = "search", required = false, defaultValue = "") String search
     ) {
         search = search.toLowerCase();
         if (size == 0) size = 10;
         if(!checkAdmin()) {
             return unauthorizedActionError();
         }
-        return ResponseEntity.ok(sanctionService.findAllByEmailOrStartDateOrEndDate(page,size,search));
+        if(search.equals("") || search.toLowerCase().equals("activas")){
+           return ResponseEntity.ok(sanctionService.getActiveSanctionList(page,size));
+        } else return ResponseEntity.ok(sanctionService.findAllByEmailOrStartDateOrEndDate(page,size,search));
     }
 
 

--- a/src/main/java/bibliotecame/back/Sanction/SanctionRepository.java
+++ b/src/main/java/bibliotecame/back/Sanction/SanctionRepository.java
@@ -18,10 +18,9 @@ public interface SanctionRepository extends PagingAndSortingRepository<SanctionM
 
     Optional<SanctionModel> findByUser(UserModel user);
 
-    @Query(value = "select b from SanctionModel b where" +
-            " b.endDate >= :today and " +
-            " lower(b.user.email) like %:search% order by b.endDate")
-    Page<SanctionModel> findAllByUserOrReasonAndActive(Pageable pageable, @Param("search") String title, @Param("today") LocalDate today);
+    @Query(value = "select s from SanctionModel s where" +
+            " s.endDate >= :today order by s.endDate")
+    Page<SanctionModel> findAllActive(Pageable pageable, @Param("today") LocalDate today);
 
     Iterable<SanctionModel> findAll();
 }

--- a/src/main/java/bibliotecame/back/Sanction/SanctionRepository.java
+++ b/src/main/java/bibliotecame/back/Sanction/SanctionRepository.java
@@ -1,8 +1,6 @@
 package bibliotecame.back.Sanction;
 
 import bibliotecame.back.User.UserModel;
-import org.springframework.data.domain.Page;
-import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.PagingAndSortingRepository;
 import org.springframework.data.repository.query.Param;
@@ -20,7 +18,7 @@ public interface SanctionRepository extends PagingAndSortingRepository<SanctionM
 
     @Query(value = "select s from SanctionModel s where" +
             " s.endDate >= :today order by s.endDate")
-    Page<SanctionModel> findAllActive(Pageable pageable, @Param("today") LocalDate today);
+    Iterable<SanctionModel> findAllActive(@Param("today") LocalDate today);
 
     Iterable<SanctionModel> findAll();
 }

--- a/src/main/java/bibliotecame/back/Sanction/SanctionService.java
+++ b/src/main/java/bibliotecame/back/Sanction/SanctionService.java
@@ -34,12 +34,13 @@ public class SanctionService {
     }
 
     public boolean userIsSanctioned(UserModel userModel){
-        return this.sanctionRepository.findByUser(userModel).isPresent();
+        return (this.sanctionRepository.findByUser(userModel).isPresent() && this.sanctionRepository.findByUser(userModel).get().getEndDate().isAfter(LocalDate.now()));
     }
 
-    public Page<SanctionModel> getSanctionList(int page, int size, String search){
+    public Page<SanctionDisplay> getActiveSanctionList(int page, int size){
         Pageable pageable = PageRequest.of(page, size);
-        return sanctionRepository.findAllByUserOrReasonAndActive(pageable, search.toLowerCase(), LocalDate.now());
+        Page<SanctionDisplay> result = sanctionRepository.findAllActive(pageable, LocalDate.now()).map(sm -> new SanctionDisplay(sm.getId(), sm.getUser().getEmail(), sm.getCreationDate(), sm.getEndDate(), sm.getReason()));
+        return result;
     }
 
     public Page<SanctionDisplay> findAllByEmailOrStartDateOrEndDate(int page, int size, String search){

--- a/src/main/java/bibliotecame/back/Sanction/SanctionService.java
+++ b/src/main/java/bibliotecame/back/Sanction/SanctionService.java
@@ -37,16 +37,11 @@ public class SanctionService {
         return (this.sanctionRepository.findByUser(userModel).isPresent() && this.sanctionRepository.findByUser(userModel).get().getEndDate().isAfter(LocalDate.now()));
     }
 
-    public Page<SanctionDisplay> getActiveSanctionList(int page, int size){
-        Pageable pageable = PageRequest.of(page, size);
-        Page<SanctionDisplay> result = sanctionRepository.findAllActive(pageable, LocalDate.now()).map(sm -> new SanctionDisplay(sm.getId(), sm.getUser().getEmail(), sm.getCreationDate(), sm.getEndDate(), sm.getReason()));
-        return result;
-    }
 
     public Page<SanctionDisplay> findAllByEmailOrStartDateOrEndDate(int page, int size, String search){
         Pageable pageable = PageRequest.of(page, size);
         List<SanctionModel> result = new ArrayList<>();
-        sanctionRepository.findAll().iterator().forEachRemaining(result::add);
+        sanctionRepository.findAllActive(LocalDate.now()).iterator().forEachRemaining(result::add);
         result = result.stream().filter(sM -> sM.getUser().getEmail().toLowerCase().contains(search) || sM.getCreationDate().toString().contains(search) || sM.getEndDate().toString().contains(search)).collect(Collectors.toList());
         int total = result.size();
         int start = toIntExact(pageable.getOffset());

--- a/src/test/java/bibliotecame/back/SanctionTest.java
+++ b/src/test/java/bibliotecame/back/SanctionTest.java
@@ -142,7 +142,7 @@ public class SanctionTest {
         userService.saveUser(new UserModel(mail, "password", "Mail", "Mail", "12345678"));
         sanctionController.createSanction(new SanctionForm(mail, "reason", LocalDate.now().plus(Period.ofDays(25))));
 
-        Page<SanctionDisplay> list = (Page<SanctionDisplay>) sanctionController.getActiveOrSearch(0, 10,"").getBody();
+        Page<SanctionDisplay> list = (Page<SanctionDisplay>) sanctionController.getActiveSanctionsWithDateOrUserFilter(0, 10,"").getBody();
         assert list != null;
         assertThat(list.getTotalElements()).isGreaterThan(3);
 
@@ -178,7 +178,7 @@ public class SanctionTest {
         userService.saveUser(NOTadmin);
         setSecurityContext(NOTadmin);
 
-        assertThat(sanctionController.getActiveOrSearch(0, 10,"").getStatusCode()).isEqualByComparingTo(HttpStatus.UNAUTHORIZED);
+        assertThat(sanctionController.getActiveSanctionsWithDateOrUserFilter(0, 10,"").getStatusCode()).isEqualByComparingTo(HttpStatus.UNAUTHORIZED);
 
 
     }
@@ -301,7 +301,7 @@ public class SanctionTest {
         sanctionController.createSanction(new SanctionForm("UserToSanctionTillNovember21@mail.austral.edu.ar","No me caia tan mal como el primero",LocalDate.of(2020, Month.NOVEMBER,21)));
         sanctionController.createSanction(new SanctionForm("UserToSanctionTillNovember29@mail.austral.edu.ar","Me caia peor que el segundo pero no tanto como el primero",LocalDate.of(2020, Month.NOVEMBER,29)));
 
-        assertThat(sanctionController.getActiveOrSearch(0,2,"usertosanctiontill").getBody().getTotalPages()).isGreaterThanOrEqualTo(2);
-        assertThat(sanctionController.getActiveOrSearch(0,10,"2020-11").getBody().getTotalElements()).isGreaterThanOrEqualTo(2);
+        assertThat(sanctionController.getActiveSanctionsWithDateOrUserFilter(0,2,"usertosanctiontill").getBody().getTotalPages()).isGreaterThanOrEqualTo(2);
+        assertThat(sanctionController.getActiveSanctionsWithDateOrUserFilter(0,10,"2020-11").getBody().getTotalElements()).isGreaterThanOrEqualTo(2);
     }
 }

--- a/src/test/java/bibliotecame/back/SanctionTest.java
+++ b/src/test/java/bibliotecame/back/SanctionTest.java
@@ -142,17 +142,9 @@ public class SanctionTest {
         userService.saveUser(new UserModel(mail, "password", "Mail", "Mail", "12345678"));
         sanctionController.createSanction(new SanctionForm(mail, "reason", LocalDate.now().plus(Period.ofDays(25))));
 
-        Page<SanctionDisplay> list = (Page<SanctionDisplay>) sanctionController.getSanctionList(0, 10, "").getBody();
+        Page<SanctionDisplay> list = (Page<SanctionDisplay>) sanctionController.getActiveOrSearch(0, 10,"").getBody();
         assert list != null;
         assertThat(list.getTotalElements()).isGreaterThan(3);
-
-        Page<SanctionDisplay> list2 = (Page<SanctionDisplay>) sanctionController.getSanctionList(0, 10, "forList").getBody();
-        assert list2 != null;
-        assertThat(list2.getTotalElements()).isEqualTo(4);
-
-        Page<SanctionDisplay> list3 = (Page<SanctionDisplay>) sanctionController.getSanctionList(0, 10, "holacomoestasholacomoestas").getBody();
-        assert list3 != null;
-        assertThat(list3.getTotalElements()).isEqualTo(0);
 
     }
 
@@ -186,7 +178,7 @@ public class SanctionTest {
         userService.saveUser(NOTadmin);
         setSecurityContext(NOTadmin);
 
-        assertThat(sanctionController.getSanctionList(0, 10, "").getStatusCode()).isEqualByComparingTo(HttpStatus.UNAUTHORIZED);
+        assertThat(sanctionController.getActiveOrSearch(0, 10,"").getStatusCode()).isEqualByComparingTo(HttpStatus.UNAUTHORIZED);
 
 
     }
@@ -309,7 +301,7 @@ public class SanctionTest {
         sanctionController.createSanction(new SanctionForm("UserToSanctionTillNovember21@mail.austral.edu.ar","No me caia tan mal como el primero",LocalDate.of(2020, Month.NOVEMBER,21)));
         sanctionController.createSanction(new SanctionForm("UserToSanctionTillNovember29@mail.austral.edu.ar","Me caia peor que el segundo pero no tanto como el primero",LocalDate.of(2020, Month.NOVEMBER,29)));
 
-        assertThat(sanctionController.getAllByEmailOrStartDateOrEndDate(0,2,"usertosanctiontill").getBody().getTotalPages()).isGreaterThanOrEqualTo(2);
-        assertThat(sanctionController.getAllByEmailOrStartDateOrEndDate(0,10,"2020-11").getBody().getTotalElements()).isGreaterThanOrEqualTo(2);
+        assertThat(sanctionController.getActiveOrSearch(0,2,"usertosanctiontill").getBody().getTotalPages()).isGreaterThanOrEqualTo(2);
+        assertThat(sanctionController.getActiveOrSearch(0,10,"2020-11").getBody().getTotalElements()).isGreaterThanOrEqualTo(2);
     }
 }


### PR DESCRIPTION
## Description

SanctionController tiene un único GET. Recibe un número de página, un tamaño, y un string para buscar.
En base a ese string retorna todas las sanciones activas que coincida su usario, fecha de finalización o fecha de creación con el string enviado, soportando busquedas wildcard. La fecha entera es en formato yyyy-mm-dd.
Si no recibe ningun string, o lo recibe vacío, devuelve todas las sanciones activas.

## ClubHouse Link

> https://app.clubhouse.io/bibliotecame/story/322/fix-sanci%C3%B3n

## Checklist
- [x] I've created and run successfully the related unit tests
- [x] I've run successfully every test in the repo
- [x] I've test the related endpoints with Postman
- [x] This pull request has 'sprint_x' as the base branch
- [x] This pull request has a descriptive title and description
- [x] I have merged the current sprint into my branch before pushing 
- [x] I've added the QA Leader as a reviewer
