### PR TITLE
Baja lógica de usuario

### DIFF
--- a/src/main/java/bibliotecame/back/Auth/AuthController.java
+++ b/src/main/java/bibliotecame/back/Auth/AuthController.java
@@ -47,6 +47,7 @@ public class AuthController {
 
         if(!user.isAdmin() && !user.isVerified()) return new ResponseEntity<>(new ErrorMessage("¡Por favor verifique su dirección de correo para poder acceder a Bibliotecame!"),HttpStatus.UNAUTHORIZED);
         if(sanctionService.userIsSanctioned(user)) return new ResponseEntity<>(new ErrorMessage("¡Usted está sancionado, por favor comuniquese con administración!"),HttpStatus.UNAUTHORIZED);
+        if(!user.isActive()) return new ResponseEntity(new ErrorMessage("¡Su cuenta está desactivada!"),HttpStatus.UNAUTHORIZED);
 
         UsernamePasswordAuthenticationToken authenticationToken =
                 new UsernamePasswordAuthenticationToken(loginForm.getEmail(), loginForm.getPassword());

--- a/src/main/java/bibliotecame/back/User/UserModel.java
+++ b/src/main/java/bibliotecame/back/User/UserModel.java
@@ -19,6 +19,9 @@ public class UserModel {
     private int id;
 
     @Column
+    private boolean active;
+
+    @Column
     private String email;
 
     @Column
@@ -45,6 +48,8 @@ public class UserModel {
 
     public UserModel() {
         loans = new ArrayList<>();
+        verified = false;
+        active = true;
     }
 
     public UserModel(String email, String password, String firstName, String lastName, String phoneNumber) {
@@ -53,6 +58,8 @@ public class UserModel {
         this.firstName = firstName;
         this.lastName = lastName;
         this.phoneNumber = phoneNumber;
+        verified = false;
+        active= true;
         loans = new ArrayList<>();
     }
 
@@ -122,5 +129,13 @@ public class UserModel {
 
     public void setVerified(boolean verified) {
         this.verified = verified;
+    }
+
+    public boolean isActive() {
+        return active;
+    }
+
+    public void setActive(boolean active) {
+        this.active = active;
     }
 }

--- a/src/main/java/bibliotecame/back/User/UserService.java
+++ b/src/main/java/bibliotecame/back/User/UserService.java
@@ -144,7 +144,8 @@ public class UserService {
     }
 
     public void deleteUser(UserModel user){
-        this.userRepository.delete(user);
+        user.setActive(false);
+        this.userRepository.save(user);
     }
 
     public boolean userExists(int id) {return this.userRepository.findById(id).isPresent(); }

--- a/src/test/java/bibliotecame/back/UserTests.java
+++ b/src/test/java/bibliotecame/back/UserTests.java
@@ -42,6 +42,7 @@ import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 
 @TestInstance(TestInstance.Lifecycle.PER_CLASS)
 @SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
@@ -176,7 +177,7 @@ public class UserTests {
         verificationService.deleteVerification(verificationService.findVerificationByUserModel(user));
         assertThat(userController.deleteUser(user.getId()).getStatusCode()).isEqualByComparingTo(HttpStatus.OK);
 
-        assertThat(((ErrorMessage)userController.getUserModel(user.getId()).getBody()).getMessage()).isEqualTo("¡El usuario no existe!");
+        assertFalse(((UserModel)userController.getUserModel(user.getId()).getBody()).isActive());
     }
 
     @Test


### PR DESCRIPTION
## Description

Para conservar la integridad de la base de datos, ahora la baja del usuario será del estilo lógica. Siempre y cuando no tenga prestamos activos, el usuario podrá desactivar su cuenta. Esta se desactivará de forma lógica, por lo que toda la información relacionada al mismo permanecerá en la aplicación.

## ClubHouse Link

> https://app.clubhouse.io/bibliotecame/story/78/resoluci%C3%B3n-de-bugs

## Checklist
- [x] I've created and run successfully the related unit tests
- [x] I've run successfully every test in the repo
- [x] I've test the related endpoints with Postman
- [x] This pull request has 'sprint_x' as the base branch
- [x] This pull request has a descriptive title and description
- [x] I have merged the current sprint into my branch before pushing 
- [x] I've added the QA Leader as a reviewer
