### PR TITLE
Sanctioned criteria fixed

### DIFF
--- a/src/main/java/bibliotecame/back/Sanction/SanctionRepository.java
+++ b/src/main/java/bibliotecame/back/Sanction/SanctionRepository.java
@@ -14,8 +14,6 @@ public interface SanctionRepository extends PagingAndSortingRepository<SanctionM
 
     Optional<SanctionModel> findById(int id);
 
-    Optional<SanctionModel> findByUser(UserModel user);
-
     @Query(value = "select s from SanctionModel s where s.user=:userModel order by s.endDate")
     Iterable<SanctionModel> findAllByUser(UserModel userModel);
 

--- a/src/main/java/bibliotecame/back/Sanction/SanctionRepository.java
+++ b/src/main/java/bibliotecame/back/Sanction/SanctionRepository.java
@@ -16,8 +16,11 @@ public interface SanctionRepository extends PagingAndSortingRepository<SanctionM
 
     Optional<SanctionModel> findByUser(UserModel user);
 
+    @Query(value = "select s from SanctionModel s where s.user=:userModel order by s.endDate")
+    Iterable<SanctionModel> findAllByUser(UserModel userModel);
+
     @Query(value = "select s from SanctionModel s where" +
-            " s.endDate >= :today order by s.endDate")
+            " s.endDate > :today order by s.endDate")
     Iterable<SanctionModel> findAllActive(@Param("today") LocalDate today);
 
     Iterable<SanctionModel> findAll();

--- a/src/main/java/bibliotecame/back/Sanction/SanctionRepository.java
+++ b/src/main/java/bibliotecame/back/Sanction/SanctionRepository.java
@@ -15,7 +15,7 @@ public interface SanctionRepository extends PagingAndSortingRepository<SanctionM
     Optional<SanctionModel> findById(int id);
 
     @Query(value = "select s from SanctionModel s where s.user=:userModel order by s.endDate")
-    Iterable<SanctionModel> findAllByUser(UserModel userModel);
+    Iterable<SanctionModel> findAllByUser(@Param("userModel") UserModel userModel);
 
     @Query(value = "select s from SanctionModel s where" +
             " s.endDate > :today order by s.endDate")

--- a/src/main/java/bibliotecame/back/Sanction/SanctionService.java
+++ b/src/main/java/bibliotecame/back/Sanction/SanctionService.java
@@ -34,7 +34,11 @@ public class SanctionService {
     }
 
     public boolean userIsSanctioned(UserModel userModel){
-        return (this.sanctionRepository.findByUser(userModel).isPresent() && this.sanctionRepository.findByUser(userModel).get().getEndDate().isAfter(LocalDate.now()));
+        SanctionModel sanction = null;
+        for (SanctionModel sanctionModel : sanctionRepository.findAllByUser(userModel)) {
+            sanction = sanctionModel;
+        }
+        return ( sanction != null && sanction.getEndDate().isAfter(LocalDate.now()));
     }
 
 


### PR DESCRIPTION
## Description

El criterio para un usuario sancionado tenía multiples fallas:
-No permitía que se vuelva a sancionar a un usuario por más que la sanción previa ya había expirado.
-En ciertas partes de la aplicación el endDate era parte del tiempo de sanción, en otras no.
Es decir, si la sanción duraba hasta el 19/10/2020 pasaba que:
> En las querys a la DB, si hoy era 19/10 el usuario seguia siendo considerado sancionado,
> En el método de IsSanctioned individual, si hoy era 19/10 el usuario ya era capaz de logear nuevamente.

Ahora esto se unificó y si la sanción finalizaba el 19/10, el 19/10 el usuario ya puede logear nuevamente, y las querys reflejan este cambio de forma correcta.

## ClubHouse Link

> https://app.clubhouse.io/bibliotecame/story/380/el-editar-sanci%C3%B3n-no-permite-ingresar-la-fecha-de-hoy

## Checklist
- [x] I've created and run successfully the related unit tests
- [x] I've run successfully every test in the repo
- [x] I've test the related endpoints with Postman
- [x] This pull request has 'sprint_x' as the base branch
- [x] This pull request has a descriptive title and description
- [x] I have merged the current sprint into my branch before pushing 
- [x] I've added the QA Leader as a reviewer
